### PR TITLE
Ensuring redirect happens only once per user from email confirmation

### DIFF
--- a/TESTING_PLAN.md
+++ b/TESTING_PLAN.md
@@ -12,13 +12,13 @@ This document provides a complete testing strategy for the AI Jobs Australia pla
 
 - **Registration**: Create job seeker account via `/login` page ✅
 - **Email Verification**: Confirm account via email link → `/auth/confirm` ✅
-- **Profile Setup**: Complete profile at `/jobseeker/profile`
-- **Document Upload**: Upload resume/cover letter at `/jobseeker/documents`
+- **Profile Setup**: Complete profile at `/jobseeker/profile` ✅
+- **Document Upload**: Upload resume/cover letter at `/jobseeker/documents` ✅
 
 #### **Job Search & Application**
 
-- **Job Browsing**: Search and filter jobs on `/jobs` page
-- **Job Details**: View full job details with company info
+- **Job Browsing**: Search and filter jobs on `/jobs` page ✅
+- **Job Details**: View full job details with company info ✅
 - **Save Jobs**: Save interesting jobs to `/jobseeker/saved-jobs`
 - **Apply for Jobs**: Submit applications via `/apply/[jobId]`
 - **Application Tracking**: Monitor status in `/jobseeker/applications`

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -1,0 +1,114 @@
+1. Branch Strategy
+
+You should use a branching strategy to keep your code organized:
+
+main (or master) → Production-ready code only
+├── develop → Integration branch for features
+├── feature/email-confirmation → Feature branches
+├── fix/redirect-issue → Bug fix branches
+└── test/user-acceptance → Testing branches
+
+2. For Your Current Testing Phase
+
+Option A: Feature Branch Workflow (Recommended)
+
+# Create a testing branch
+
+git checkout -b test/email-confirmation-flow
+
+# Make your changes and test
+
+git add .
+git commit -m "test: email confirmation redirect flow"
+git push origin test/email-confirmation-flow
+
+# Vercel will auto-deploy this branch to a preview URL
+
+# Test thoroughly on the preview URL
+
+# Once confirmed working, merge to main
+
+git checkout main
+git merge test/email-confirmation-flow
+git push origin main
+
+3. Vercel Preview Deployments
+
+Vercel automatically creates preview deployments for every branch:
+
+- main branch → Production URL (ai-jobs-australia-v1.vercel.app)
+- Other branches → Preview URLs (ai-jobs-australia-v1-[branch-hash].vercel.app)
+
+4. Best Practices for Testing Phase
+
+DO:
+
+- Create feature/test branches for experimental changes
+- Use descriptive branch names (test/jobseeker-profile-redirect)
+- Test on preview URLs before merging to main
+- Keep main branch stable and working
+- Use pull requests for code review
+
+DON'T:
+
+- Push experimental changes directly to main
+- Test in production
+- Mix multiple features in one branch
+
+5.  Typical Testing Workflow
+
+# 1. Start a new test feature
+
+git checkout -b test/new-feature
+
+# 2. Make changes and commit frequently
+
+git add .
+git commit -m "test: trying new approach for X"
+
+# 3. Push to GitHub (triggers Vercel preview)
+
+git push origin test/new-feature
+
+# 4. Test on preview URL
+
+# If it works → Create PR and merge
+
+# If it doesn't → Fix or abandon branch
+
+# 5. Clean up after merging
+
+git checkout main
+git pull origin main
+git branch -d test/new-feature
+
+6. Environment Variables
+
+For different environments:
+
+- Local: .env.local (not committed)
+- Preview: Set in Vercel dashboard for preview deployments
+- Production: Set in Vercel dashboard for production
+
+7. Your Current Situation
+
+Since you've been testing email confirmation:
+
+# Create a branch for the current work
+
+git checkout -b feature/email-confirmation-redirect
+
+# Commit the working solution
+
+git add .
+git commit -m "feat: add email confirmation redirect to profile page"
+
+# Push to GitHub
+
+git push origin feature/email-confirmation-redirect
+
+# Create a Pull Request on GitHub
+
+# Review the changes
+
+# Merge to main when ready


### PR DESCRIPTION
 ## Changes
  - Fixed infinite redirect loop for logged-in users on home page
  - Added one-time redirect logic for newly verified users
  - Users are redirected to profile page only once after email confirmation
  - Subsequent visits allow normal navigation

  ## Testing
  - Tested email confirmation flow with new users
  - Verified redirect only happens once
  - Confirmed existing users can navigate normally

  ## Issue Fixed
  - Users were stuck in redirect loop when trying to access home page
  - Now redirect only triggers once per user after email verification