### PR TITLE
Add rel=nofollow to internal links to robots-blocked auth paths

### DIFF
--- a/app/hire/page.tsx
+++ b/app/hire/page.tsx
@@ -144,7 +144,7 @@ export default function HirePage() {
           </p>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link href="/post-job-login">
+            <Link href="/post-job-login" rel="nofollow">
               <Button
                 size="lg"
                 className="bg-gradient-hero hover:opacity-90 text-white font-semibold px-8 py-6 text-lg"
@@ -599,7 +599,7 @@ export default function HirePage() {
             Start reaching qualified AI candidates today.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link href="/post-job-login">
+            <Link href="/post-job-login" rel="nofollow">
               <Button
                 size="lg"
                 className="bg-gradient-hero hover:opacity-90 text-white font-semibold px-8 py-6 text-lg"

--- a/app/jobs/category/[slug]/[city]/page.tsx
+++ b/app/jobs/category/[slug]/[city]/page.tsx
@@ -228,6 +228,7 @@ export default async function CategoryLocationPage({ params }: CrossPageProps) {
               </p>
               <Link
                 href={`/login?next=${encodeURIComponent(`/jobs/category/${slug}/${city}`)}`}
+                rel="nofollow"
                 className="inline-block bg-primary text-primary-foreground hover:bg-primary/90 font-medium py-2 px-6 rounded-lg transition-colors"
               >
                 Sign Up Free

--- a/app/tools/ai-career-path-quiz/page.tsx
+++ b/app/tools/ai-career-path-quiz/page.tsx
@@ -199,7 +199,7 @@ export default function AICareerPathQuizPage() {
               className="bg-white/10 hover:bg-white/20 text-white border-white/30"
               asChild
             >
-              <Link href="/login">Create Free Profile</Link>
+              <Link href="/login" rel="nofollow">Create Free Profile</Link>
             </Button>
           </div>
         </div>

--- a/app/tools/ai-interview-question-generator/page.tsx
+++ b/app/tools/ai-interview-question-generator/page.tsx
@@ -213,7 +213,7 @@ export default function InterviewQuestionGeneratorPage() {
               className="bg-white/10 hover:bg-white/20 text-white border-white/30"
               asChild
             >
-              <Link href="/login">Create Free Profile</Link>
+              <Link href="/login" rel="nofollow">Create Free Profile</Link>
             </Button>
           </div>
         </div>

--- a/app/tools/ai-jobs-resume-keyword-analyser/page.tsx
+++ b/app/tools/ai-jobs-resume-keyword-analyser/page.tsx
@@ -197,7 +197,7 @@ export default function ResumeKeywordAnalyzerPage() {
               className="bg-white/10 hover:bg-white/20 text-white border-white/30"
               asChild
             >
-              <Link href="/login">Create Free Profile</Link>
+              <Link href="/login" rel="nofollow">Create Free Profile</Link>
             </Button>
           </div>
         </div>

--- a/app/tools/ai-ml-salary-calculator/page.tsx
+++ b/app/tools/ai-ml-salary-calculator/page.tsx
@@ -216,7 +216,7 @@ export default function SalaryCalculatorPage() {
               className="bg-white/10 hover:bg-white/20 text-white border-white/30"
               asChild
             >
-              <Link href="/login">Create Free Profile</Link>
+              <Link href="/login" rel="nofollow">Create Free Profile</Link>
             </Button>
           </div>
         </div>

--- a/app/tools/ai-portfolio-project-generator/page.tsx
+++ b/app/tools/ai-portfolio-project-generator/page.tsx
@@ -325,7 +325,7 @@ export default function PortfolioProjectGeneratorPage() {
               className="bg-white/10 hover:bg-white/20 text-white border-white/30"
               asChild
             >
-              <Link href="/login">Create Free Profile</Link>
+              <Link href="/login" rel="nofollow">Create Free Profile</Link>
             </Button>
           </div>
         </div>

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -330,7 +330,7 @@ export default function ToolsPage() {
               className="bg-white/10 hover:bg-white/20 text-white border-white/30"
               asChild
             >
-              <Link href="/login">Create Free Profile</Link>
+              <Link href="/login" rel="nofollow">Create Free Profile</Link>
             </Button>
           </div>
         </div>

--- a/components/EmployerHeader.tsx
+++ b/components/EmployerHeader.tsx
@@ -90,7 +90,7 @@ const EmployerHeader = () => {
                 </Button>
               </>
             ) : (
-              <Link href="/post-job-login">
+              <Link href="/post-job-login" rel="nofollow">
                 <Button variant="default" size="sm">
                   Sign In
                 </Button>
@@ -152,6 +152,7 @@ const EmployerHeader = () => {
               ) : (
                 <Link
                   href="/employer-login"
+                  rel="nofollow"
                   onClick={closeMobileMenu}
                   className="flex items-center gap-3 py-3 px-2 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md transition-colors font-medium"
                 >

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -213,6 +213,7 @@ const Footer = () => {
                 <li>
                   <Link
                     href="/login"
+                    rel="nofollow"
                     className="hover:text-background transition-smooth"
                   >
                     Job Seeker Sign In
@@ -221,6 +222,7 @@ const Footer = () => {
                 <li>
                   <Link
                     href="/employer-login"
+                    rel="nofollow"
                     className="hover:text-background transition-smooth"
                   >
                     Employer Sign In

--- a/components/jobs/SignupOrViewAllCard.tsx
+++ b/components/jobs/SignupOrViewAllCard.tsx
@@ -140,13 +140,14 @@ export const SignupOrViewAllCard: React.FC<SignupOrViewAllCardProps> = ({
         <div className="max-w-md mx-auto space-y-4">
           <Link
             href={`/login?next=${encodeURIComponent(redirectPath)}`}
+            rel="nofollow"
             className="inline-block w-full bg-primary text-primary-foreground hover:bg-primary/90 font-medium py-3 px-6 rounded-lg transition-colors"
           >
             Sign Up Free - View All Jobs
           </Link>
           <p className="text-sm text-muted-foreground">
             Already have an account?{' '}
-            <Link href="/login" className="text-primary hover:underline font-medium">
+            <Link href="/login" rel="nofollow" className="text-primary hover:underline font-medium">
               Sign in
             </Link>
           </p>


### PR DESCRIPTION
## Summary

Googlebot was following internal links to `/login`, `/login?next=…`, `/employer-login` and `/post-job-login` from publicly-crawlable pages. All those paths are disallowed in `robots.txt`, so every follow landed in GSC's **Blocked by robots.txt** report — 99 URLs, mostly `/login?next=/jobs/category/…` and `/login?next=/jobs/location/…` generated by the "Sign Up Free - View All Jobs" CTA.

`rel="nofollow"` tells Google not to follow these links at all, so the internal signal leak stops and the block count drops as Google re-crawls.

## Files touched

- \`components/Footer.tsx\` — appears on every page: \`/login\`, \`/employer-login\`
- \`components/jobs/SignupOrViewAllCard.tsx\` — category/location pages: \`/login?next=…\`, \`/login\`
- \`app/jobs/category/[slug]/[city]/page.tsx\` — \`/login?next=…\`
- \`components/EmployerHeader.tsx\` (used on \`/hire\`) — \`/post-job-login\`, \`/employer-login\`
- \`app/hire/page.tsx\` — two \`/post-job-login\` CTAs
- Six tool pages (\`/tools\`, ai-portfolio-project-generator, ai-ml-salary-calculator, ai-career-path-quiz, ai-interview-question-generator, ai-jobs-resume-keyword-analyser) — each with a \`/login\` "Create Free Profile" CTA

## Test plan

- [ ] View page source on \`/\`, \`/hire\`, \`/jobs/location/sydney\`, \`/jobs/category/data-science\`, \`/tools\`, \`/tools/ai-ml-salary-calculator\` — every link to \`/login\`, \`/employer-login\` or \`/post-job-login\` has \`rel="nofollow"\`
- [ ] Clicking "Sign In" in Footer still works for real users (nofollow doesn't block browsers)
- [ ] Clicking "Create Free Profile" on a tool page still works
- [ ] No visible UI regression — \`rel\` is invisible to users

## Follow-up

Re-run GSC validation on "Blocked by robots.txt" in ~2 weeks — count should trend toward near-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)