### PR TITLE
Recover more legacy location 404s from GSC Coverage report

### DIFF
--- a/app/jobs/location/[city]/page.tsx
+++ b/app/jobs/location/[city]/page.tsx
@@ -170,6 +170,9 @@ const LEGACY_SLUG_REDIRECTS: Record<string, string> = {
   'tas': 'tasmania',
   'act': 'australian-capital-territory',
   'nt': 'northern-territory',
+  // Parser artefact: "Australia (Remote)" indexed as 'australia-remote'.
+  // Redirect to the remote jobs landing page which is a valid route.
+  'australia-remote': 'remote',
 };
 
 interface Job {

--- a/lib/locations/au-suburbs.ts
+++ b/lib/locations/au-suburbs.ts
@@ -615,6 +615,26 @@ export const AU_SUBURBS: readonly AuSuburb[] = [
   // ────────────────────────────────────────────────────────────────
   { slug: 'city-of-darwin', state: 'nt', displayName: 'City of Darwin' },
   { slug: 'city-of-palmerston', state: 'nt', displayName: 'City of Palmerston' },
+
+  // ────────────────────────────────────────────────────────────────
+  // Legacy slug recovery — suburbs appearing in GSC "Not found (404)"
+  // reports that weren't in the curated list. Each resolves to its
+  // parent state via resolveSuburbSlugToState so crawled URLs stop
+  // 404ing and the historical link equity flows to the state page.
+  // ────────────────────────────────────────────────────────────────
+  { slug: 'woollahra', state: 'nsw', displayName: 'Woollahra' },
+  { slug: 'newcastle-and-maitland', state: 'nsw', displayName: 'Newcastle and Maitland' },
+  { slug: 'carlton-north', state: 'vic', displayName: 'Carlton North' },
+  { slug: 'knoxfield', state: 'vic', displayName: 'Knoxfield' },
+  { slug: 'footscray-park', state: 'vic', displayName: 'Footscray Park' },
+  { slug: 'ballarat-central', state: 'vic', displayName: 'Ballarat Central' },
+  { slug: 'cairns-region', state: 'qld', displayName: 'Cairns Region' },
+  { slug: 'cannon-hill', state: 'qld', displayName: 'Cannon Hill' },
+  { slug: 'murarrie', state: 'qld', displayName: 'Murarrie' },
+  { slug: 'bentley', state: 'wa', displayName: 'Bentley' },
+  { slug: 'murdoch', state: 'wa', displayName: 'Murdoch' },
+  { slug: 'edinburgh', state: 'sa', displayName: 'Edinburgh' },
+  { slug: 'conder', state: 'act', displayName: 'Conder' },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds 13 suburbs (woollahra, newcastle-and-maitland, carlton-north, knoxfield, footscray-park, ballarat-central, cairns-region, cannon-hill, murarrie, bentley, murdoch, edinburgh, conder) to `AU_SUBURBS` so `resolveLegacyLocationSlug` routes them to their parent state page.
- Adds `australia-remote` → `remote` to `LEGACY_SLUG_REDIRECTS` for the parser artefact where "Australia (Remote)" was indexed with the country prefix.
- Resolves 116 of the 117 location URLs in the 2026-04-24 GSC Coverage drilldown (was 102/117 prior). Only `australia-new-zealand` remains — no sensible redirect target.

## Context
The GSC Coverage "Not found (404)" report was at 416 URLs on 2026-04-24. The 117 location URLs in that report were mostly crawled before `b18b4f2` shipped the legacy-slug resolver on 2026-04-21; this PR closes the remaining gaps by populating `AU_SUBURBS` with the stragglers that weren't in the curated list.

Expected impact once Google recrawls: location 404s drop from 117 → 1.

## Test plan
- [x] `npm run lint` passes
- [ ] Verify `/jobs/location/carlton-north` 301s to `/jobs/location/victoria` on the deploy preview
- [ ] Verify `/jobs/location/australia-remote` 301s to `/jobs/location/remote`
- [ ] Hit "Validate Fix" in GSC after merge to accelerate recrawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)