### PR TITLE
Fix GSC soft 404s and surface state pages for crawl

### DIFF
--- a/app/blog/[slug]/layout.tsx
+++ b/app/blog/[slug]/layout.tsx
@@ -1,19 +1,17 @@
+import { cache } from 'react';
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { createClient } from '@supabase/supabase-js';
 
 interface Props {
   params: Promise<{ slug: string }>;
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug } = await params;
-
-  // Check for required env vars - return default metadata if missing
+// Cached so generateMetadata and the layout share a single DB lookup per
+// request. React's cache() de-dupes by argument value within a render.
+const getPublishedPost = cache(async (slug: string) => {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    return {
-      title: 'Blog | AI Jobs Australia',
-      description: 'Read the latest articles about AI jobs and careers in Australia.',
-    };
+    return null;
   }
 
   const supabase = createClient(
@@ -21,14 +19,25 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     process.env.SUPABASE_SERVICE_ROLE_KEY
   );
 
-  const { data: post } = await supabase
+  const { data } = await supabase
     .from('blog_posts')
     .select('*')
     .eq('slug', slug)
     .eq('status', 'published')
     .single();
 
+  return data;
+});
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getPublishedPost(slug);
+
   if (!post) {
+    // The layout default export will call notFound() and render the
+    // root not-found page with a real 404 status. Metadata returned
+    // here is overridden by the not-found page's own metadata, but we
+    // set it anyway in case the not-found render is bypassed.
     return {
       title: 'Article Not Found | AI Jobs Australia',
       description: 'The requested article could not be found.',
@@ -56,10 +65,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default function BlogArticleLayout({
+export default async function BlogArticleLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: Promise<{ slug: string }>;
 }) {
+  const { slug } = await params;
+  const post = await getPublishedPost(slug);
+
+  // Without this, unpublished/deleted posts return HTTP 200 with the
+  // client-side "Article Not Found" UI — Google classifies that as
+  // soft 404. notFound() returns a real 404 status.
+  if (!post) {
+    notFound();
+  }
+
   return children;
 }

--- a/app/jobs/search/[slug]/page.tsx
+++ b/app/jobs/search/[slug]/page.tsx
@@ -70,21 +70,19 @@ export default async function SearchPage({ params }: SearchPageProps) {
   const { slug } = await params;
 
   // Suburb-level SEO URL (e.g. /jobs/search/ai-engineer-richmond-vic).
-  // 308-redirect to the state-filtered job search so the ranking signal
-  // consolidates onto the canonical /jobs?search=&location= page and the
-  // user lands on /jobs with both the keyword and state dropdown pre-filled.
-  //
-  // `match=broad` mirrors SearchPageRedirect behaviour for the curated
-  // keyword pages — searches title OR description (not title-only), so a
-  // "AI Engineer" job listing with the role in the description still
-  // surfaces. `guest=true` skips the auth redirect for unauthenticated
-  // visitors landing from search.
+  // 308-redirect to the curated keyword landing page (/jobs/search/<keyword>)
+  // rather than the state-filtered /jobs listing — Google was classifying
+  // the latter as soft-404 for low-job states (TAS/NT/WA) where the
+  // state-filtered destination came back empty. The keyword landing page
+  // is always populated (its getSearchKeywordJobs helper fills to ~9 with
+  // related-keyword fallbacks), preserving the visitor's keyword intent
+  // and giving Google a content-rich destination. The state filter is
+  // dropped — niche-state job markets are too thin for the filter to add
+  // useful surface area, and same trade-off the legacy-category redirect
+  // ladder already makes (see legacyCategorySlugToRedirect).
   const suburbMatch = parseSuburbSearchSlug(slug);
   if (suburbMatch) {
-    const { keyword, suburb } = suburbMatch;
-    permanentRedirect(
-      `/jobs?search=${encodeURIComponent(keyword.keyword)}&location=${suburb.state}&guest=true&match=broad`,
-    );
+    permanentRedirect(`/jobs/search/${suburbMatch.keyword.slug}`);
   }
 
   // Invalid slug — redirect to main jobs page

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           {/* Main Footer Content */}
-          <div className="grid lg:grid-cols-6 gap-8 mb-12">
+          <div className="grid lg:grid-cols-7 gap-8 mb-12">
             {/* Brand */}
             <div className="lg:col-span-2">
               <div className="flex items-center space-x-2 mb-4">
@@ -161,6 +161,77 @@ const Footer = () => {
                     className="hover:text-background transition-smooth"
                   >
                     Remote AI Jobs
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+
+            {/* States */}
+            <nav aria-label="Browse by State">
+              <h4 className="font-semibold mb-4">Browse by State</h4>
+              <ul className="space-y-2 text-background/80">
+                <li>
+                  <Link
+                    href="/jobs/location/new-south-wales"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in NSW
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/victoria"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in Victoria
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/queensland"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in Queensland
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/western-australia"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in WA
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/south-australia"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in SA
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/australian-capital-territory"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in ACT
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/tasmania"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in Tasmania
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/jobs/location/northern-territory"
+                    className="hover:text-background transition-smooth"
+                  >
+                    AI Jobs in NT
                   </Link>
                 </li>
               </ul>

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,11 @@ const nextConfig: NextConfig = {
         destination: '/tools/ai-skills-gap-analyser',
         permanent: true,
       },
+      {
+        source: '/blog/how-many-references-for-a-resume-for-ai-and-data-cience-in-australia',
+        destination: '/blog/how-many-references-for-a-resume-for-ai-and-data-science-in-australia',
+        permanent: true,
+      },
     ];
   },
 };

--- a/scripts/fix-data-science-blog-slug.sql
+++ b/scripts/fix-data-science-blog-slug.sql
@@ -1,0 +1,25 @@
+-- Fix typo in blog post slug: "data-cience" -> "data-science"
+--
+-- Background: this post appeared in GSC's "Crawled - currently not indexed"
+-- report. Google won't index a misspelled slug because nobody links to or
+-- searches for "data cience". Fixing the slug + adding a permanent redirect
+-- in next.config.ts preserves any existing link equity.
+--
+-- Run order: execute this SQL first (atomic single-row UPDATE), then deploy
+-- the next.config.ts redirect. Brief window where the old URL 404s before
+-- the redirect deploy is acceptable — the new URL is live immediately.
+
+-- Sanity check before update — should return exactly 1 row
+SELECT id, slug, title, status
+FROM blog_posts
+WHERE slug = 'how-many-references-for-a-resume-for-ai-and-data-cience-in-australia';
+
+-- Apply the fix
+UPDATE blog_posts
+SET slug = 'how-many-references-for-a-resume-for-ai-and-data-science-in-australia'
+WHERE slug = 'how-many-references-for-a-resume-for-ai-and-data-cience-in-australia';
+
+-- Confirm the new slug is in place
+SELECT id, slug, title, status
+FROM blog_posts
+WHERE slug = 'how-many-references-for-a-resume-for-ai-and-data-science-in-australia';


### PR DESCRIPTION
## Summary

Audited GSC Coverage drilldowns across **Soft 404**, **Crawled - currently not indexed**, and **Discovered - currently not indexed** buckets. Identified four real bugs, fixed each.

- **Soft 404 (129 URLs)** — keyword×suburb redirects landing on empty state-filtered listings (TAS/WA/NT). Now redirect to the curated keyword landing page which always has content.
- **Soft 404 (1 URL) + future-proofing** — `/blog/[slug]` returned HTTP 200 with "Article Not Found" title for unpublished posts. Now returns a proper HTTP 404.
- **Discovered - not indexed (state pages)** — state pages had zero internal links anywhere in the codebase. Added "Browse by State" section to the Footer.
- **Crawled - not indexed (1 blog post)** — fixed slug typo `data-cience` → `data-science` with a permanent redirect.

## Changes

### `app/jobs/search/[slug]/page.tsx`
Suburb-bearing search slug redirect target changed:
- **Was:** `/jobs/search/ai-engineer-richmond-vic` → `/jobs?search=AI%20Engineer&location=vic&guest=true&match=broad`
- **Now:** `/jobs/search/ai-engineer-richmond-vic` → `/jobs/search/ai-engineer`

State filter is dropped — niche-state markets (TAS/NT) are too thin for the filter to add value, and the keyword landing page is always populated by `getSearchKeywordJobs` filling to ~9 results with related-keyword fallbacks. Mirrors the trade-off `legacyCategorySlugToRedirect` already makes.

### `app/blog/[slug]/layout.tsx`
- Wrapped the post lookup in `React.cache()` so `generateMetadata` and the layout share a single DB query per request.
- Layout default export calls `notFound()` when the post is missing/unpublished, returning real HTTP 404 instead of 200 with a misleading title.

### `components/Footer.tsx`
Added a 5th nav column "Browse by State" with all 8 state pages (NSW, Victoria, Queensland, WA, SA, ACT, Tasmania, NT). Grid changed from `lg:grid-cols-6` to `lg:grid-cols-7`. State pages were sitting in "Discovered - currently not indexed" with crawl date 1970-01-01 because the existing "Browse by Location" only had capital cities — Google had no internal-link signal to prioritise crawling them.

### `next.config.ts` + `scripts/fix-data-science-blog-slug.sql`
- Permanent redirect for the typo'd blog slug.
- One-off SQL migration to update the `blog_posts` row.

## Deploy order

1. **Run the SQL first** (atomic single-row UPDATE in Supabase SQL Editor). Brief window where the old slug 404s; the post is immediately accessible at the new URL.
2. **Deploy this PR.** Old slug → 308 → new slug. Inbound links recovered.

## Test plan

- [ ] After deploy, verify soft 404 redirect: `curl -sI "https://www.aijobsaustralia.com.au/jobs/search/ai-engineer-richmond-vic"` should return 308 → `/jobs/search/ai-engineer`
- [ ] After deploy, verify blog redirect: `curl -sI "https://www.aijobsaustralia.com.au/blog/how-many-references-for-a-resume-for-ai-and-data-cience-in-australia"` should return 308 → `data-science` slug
- [ ] After deploy, verify blog 404 status for unpublished post (test by setting `status != 'published'` on a post and checking `curl -sI` returns HTTP 404)
- [ ] Confirm Footer renders "Browse by State" section across desktop and mobile breakpoints
- [ ] In GSC after ~1 week: click "Validate Fix" on Soft 404 issue and watch the bucket drain
- [ ] In GSC after ~2 weeks: confirm state pages have moved out of "Discovered - currently not indexed" into "Indexed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)